### PR TITLE
Add build and release GitHub action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Build and Release DOSBox
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential automake autoconf libtool libsdl1.2-dev libpng-dev zlib1g-dev libasound2-dev libncurses5-dev
+      - name: Build
+        run: |
+          ./autogen.sh
+          ./configure
+          make -j$(nproc)
+      - name: Package
+        run: |
+          tar -czf dosbox-${{ github.ref_name }}.tar.gz -C src dosbox
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "dosbox-${{ github.ref_name }}.tar.gz"
+          tag: ${{ github.ref_name }}
+          name: "Release ${{ github.ref_name }}"
+          generateReleaseNotes: true


### PR DESCRIPTION
## Summary
- automate tagged releases with a GitHub Actions workflow

## Testing
- `git status --short`